### PR TITLE
INF-474/feat: Migrate GitHub Actions runners to vars.RUNNER_STANDARD

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_STANDARD }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Migrates `ubuntu-latest` to `vars.RUNNER_STANDARD` in deploy.yaml
- Part of infrastructure-wide migration to standardise runner variables

## Changes
- Updated all jobs using `ubuntu-latest`

## Related
- Linear: INF-474