### PR TITLE
INF-780/chore: use HTTPS URL for git-hooks pre-commit repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Alternatively, you can use ssh
 
 ```yaml
 # .pre-commit-config.yaml
-- repo: git@github.com:two-inc/git-hooks.git
+- repo: https://github.com/two-inc/git-hooks
   rev: 25.08.04
     hooks:
       - id: commit-type-with-linear-ref


### PR DESCRIPTION
git-hooks is a public repo — SSH URL is unnecessary and requires BOT_SSH_PRIVATE_KEY secret in CI.