### PR TITLE
chore(INF-912): follow-up bump of remaining node20 actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.10'
       - name: Install dependencies


### PR DESCRIPTION
## What

Follow-up to [INF-912](https://linear.app/tillit/issue/INF-912) — the first sweep merged before some action majors were verified node24.

Bumps remaining node20 pins to their node24 successors. Mechanical change, no breaking inputs.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
